### PR TITLE
Changed the name of the landing page

### DIFF
--- a/src/test/resources/features/IssuesFromCarl.feature
+++ b/src/test/resources/features/IssuesFromCarl.feature
@@ -5,7 +5,7 @@ Feature: Issues from Carl
 
   Scenario: Navigate to the Home page
     Given the user navigates to the shop homepage
-    Then the page title should be "Webbutiken"
+    Then the page title should be "The Shop"
 
   Scenario: Navigate to the Shop page
     Given the user navigates to the shop homepage


### PR DESCRIPTION
The web shop was updated yesterday. One of my test broke.

Now it's fixed and runs green. The title of the page changed from "Webbutiken" to "The Shop" 